### PR TITLE
new GLES 2.0 sample: es2gears

### DIFF
--- a/orbis_es2gears/Makefile
+++ b/orbis_es2gears/Makefile
@@ -1,0 +1,18 @@
+ifndef Ps4Sdk
+ifdef ps4sdk
+Ps4Sdk := $(ps4sdk)
+endif
+ifdef PS4SDK
+Ps4Sdk := $(PS4SDK)
+endif
+ifndef Ps4Sdk
+$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
+endif
+endif
+
+target ?= ps4_elf
+TargetFile=homebrew.elf
+
+include $(Ps4Sdk)/make/ps4sdk.mk
+LinkerFlags+=-ldebugnet -lps4link -lelfloader -lSceNet_stub -lScePigletv2VSH_stub -lSceSystemService_stub
+

--- a/orbis_es2gears/Makefile
+++ b/orbis_es2gears/Makefile
@@ -14,5 +14,5 @@ target ?= ps4_elf
 TargetFile=homebrew.elf
 
 include $(Ps4Sdk)/make/ps4sdk.mk
-LinkerFlags+=-ldebugnet -lps4link -lelfloader -lSceNet_stub -lScePigletv2VSH_stub -lSceSystemService_stub
+LinkerFlags+=-ldebugnet -lps4link -lelfloader -lSceNet_stub -lorbisGl -lorbisFile -lScePigletv2VSH_stub -lSceSystemService_stub
 

--- a/orbis_es2gears/Makefile
+++ b/orbis_es2gears/Makefile
@@ -14,5 +14,5 @@ target ?= ps4_elf
 TargetFile=homebrew.elf
 
 include $(Ps4Sdk)/make/ps4sdk.mk
-LinkerFlags+=-ldebugnet -lps4link -lelfloader -lSceNet_stub -lorbisGl -lorbisFile -lScePigletv2VSH_stub -lSceSystemService_stub
+LinkerFlags+=-ldebugnet -lps4link -lorbisFile -lelfloader -lorbisKeyboard -lorbisGl -lorbisPad -lorbisAudio -lmod -lSceNet_stub -lScePigletv2VSH_stub -lSceSystemService_stub -lSceUserService_stub -lScePad_stub -lSceAudioOut_stub -lSceIme_stub -lSceSysmodule_stub
 

--- a/orbis_es2gears/source/es2gears.c
+++ b/orbis_es2gears/source/es2gears.c
@@ -35,8 +35,8 @@
  * Jul 13, 2010
  */
 
-#define GL_GLEXT_PROTOTYPES
-#define EGL_EGLEXT_PROTOTYPES
+/*#define GL_GLEXT_PROTOTYPES
+#define EGL_EGLEXT_PROTOTYPES*/
 
 #define _GNU_SOURCE
 
@@ -49,7 +49,7 @@
 #include <GLES2/gl2.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-//#include "eglut.h"
+#include <orbisGl.h>
 #include <debugnet.h>
 
 #define STRIPS_PER_TOOTH 7
@@ -748,7 +748,7 @@ test(int argc, char *argv[])
    /* Initialize the gears */
    gears_init();
    
-   gears_reshape(1920, 1080);
+   gears_reshape(ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT);
 
    //eglutMainLoop();
 

--- a/orbis_es2gears/source/es2gears.c
+++ b/orbis_es2gears/source/es2gears.c
@@ -1,0 +1,756 @@
+/*
+ * Copyright (C) 1999-2001  Brian Paul   All Rights Reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * BRIAN PAUL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Ported to GLES2.
+ * Kristian Høgsberg <krh@bitplanet.net>
+ * May 3, 2010
+ * 
+ * Improve GLES2 port:
+ *   * Refactor gear drawing.
+ *   * Use correct normals for surfaces.
+ *   * Improve shader.
+ *   * Use perspective projection transformation.
+ *   * Add FPS count.
+ *   * Add comments.
+ * Alexandros Frantzis <alexandros.frantzis@linaro.org>
+ * Jul 13, 2010
+ */
+
+#define GL_GLEXT_PROTOTYPES
+#define EGL_EGLEXT_PROTOTYPES
+
+#define _GNU_SOURCE
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <GLES2/gl2.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+//#include "eglut.h"
+#include <debugnet.h>
+
+#define STRIPS_PER_TOOTH 7
+#define VERTICES_PER_TOOTH 34
+#define GEAR_VERTEX_STRIDE 6
+
+/**
+ * Struct describing the vertices in triangle strip
+ */
+struct vertex_strip {
+   /** The first vertex in the strip */
+   GLint first;
+   /** The number of consecutive vertices in the strip after the first */
+   GLint count;
+};
+
+/* Each vertex consist of GEAR_VERTEX_STRIDE GLfloat attributes */
+typedef GLfloat GearVertex[GEAR_VERTEX_STRIDE];
+
+/**
+ * Struct representing a gear.
+ */
+struct gear {
+   /** The array of vertices comprising the gear */
+   GearVertex *vertices;
+   /** The number of vertices comprising the gear */
+   int nvertices;
+   /** The array of triangle strips comprising the gear */
+   struct vertex_strip *strips;
+   /** The number of triangle strips comprising the gear */
+   int nstrips;
+   /** The Vertex Buffer Object holding the vertices in the graphics card */
+   GLuint vbo;
+};
+
+/** The view rotation [x, y, z] */
+static GLfloat view_rot[3] = { 20.0, 30.0, 0.0 };
+/** The gears */
+static struct gear *gear1, *gear2, *gear3;
+/** The current gear rotation angle */
+static GLfloat angle = 0.0;
+/** The location of the shader uniforms */
+static GLuint ModelViewProjectionMatrix_location,
+              NormalMatrix_location,
+              LightSourcePosition_location,
+              MaterialColor_location;
+/** The projection matrix */
+static GLfloat ProjectionMatrix[16];
+/** The direction of the directional light for the scene */
+static const GLfloat LightSourcePosition[4] = { 5.0, 5.0, 10.0, 1.0};
+
+/** 
+ * Fills a gear vertex.
+ * 
+ * @param v the vertex to fill
+ * @param x the x coordinate
+ * @param y the y coordinate
+ * @param z the z coortinate
+ * @param n pointer to the normal table 
+ * 
+ * @return the operation error code
+ */
+static GearVertex *
+vert(GearVertex *v, GLfloat x, GLfloat y, GLfloat z, GLfloat n[3])
+{
+   v[0][0] = x;
+   v[0][1] = y;
+   v[0][2] = z;
+   v[0][3] = n[0];
+   v[0][4] = n[1];
+   v[0][5] = n[2];
+
+   return v + 1;
+}
+
+/**
+ *  Create a gear wheel.
+ * 
+ *  @param inner_radius radius of hole at center
+ *  @param outer_radius radius at center of teeth
+ *  @param width width of gear
+ *  @param teeth number of teeth
+ *  @param tooth_depth depth of tooth
+ *  
+ *  @return pointer to the constructed struct gear
+ */
+static struct gear *
+create_gear(GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
+      GLint teeth, GLfloat tooth_depth)
+{
+   GLfloat r0, r1, r2;
+   GLfloat da;
+   GearVertex *v;
+   struct gear *gear;
+   double s[5], c[5];
+   GLfloat normal[3];
+   int cur_strip = 0;
+   int i;
+
+   /* Allocate memory for the gear */
+   gear = malloc(sizeof *gear);
+   if (gear == NULL)
+      return NULL;
+
+   /* Calculate the radii used in the gear */
+   r0 = inner_radius;
+   r1 = outer_radius - tooth_depth / 2.0;
+   r2 = outer_radius + tooth_depth / 2.0;
+
+   da = 2.0 * M_PI / teeth / 4.0;
+
+   /* Allocate memory for the triangle strip information */
+   gear->nstrips = STRIPS_PER_TOOTH * teeth;
+   gear->strips = calloc(gear->nstrips, sizeof (*gear->strips));
+
+   /* Allocate memory for the vertices */
+   gear->vertices = calloc(VERTICES_PER_TOOTH * teeth, sizeof(*gear->vertices));
+   v = gear->vertices;
+
+   for (i = 0; i < teeth; i++) {
+      /* Calculate needed sin/cos for varius angles */
+      s[0] = sin(i * 2.0 * M_PI / teeth);           c[0] = cos(i * 2.0 * M_PI / teeth);
+      s[1] = sin(i * 2.0 * M_PI / teeth + da);      c[1] = cos(i * 2.0 * M_PI / teeth + da);
+      s[2] = sin(i * 2.0 * M_PI / teeth + da * 2);  c[2] = cos(i * 2.0 * M_PI / teeth + da * 2);
+      s[3] = sin(i * 2.0 * M_PI / teeth + da * 3);  c[3] = cos(i * 2.0 * M_PI / teeth + da * 3);
+      s[4] = sin(i * 2.0 * M_PI / teeth + da * 4);  c[4] = cos(i * 2.0 * M_PI / teeth + da * 4);
+      
+      /*
+      sincos(i * 2.0 * M_PI / teeth, &s[0], &c[0]);
+      sincos(i * 2.0 * M_PI / teeth + da, &s[1], &c[1]);
+      sincos(i * 2.0 * M_PI / teeth + da * 2, &s[2], &c[2]);
+      sincos(i * 2.0 * M_PI / teeth + da * 3, &s[3], &c[3]);
+      sincos(i * 2.0 * M_PI / teeth + da * 4, &s[4], &c[4]);*/
+
+      /* A set of macros for making the creation of the gears easier */
+#define  GEAR_POINT(r, da) { (r) * c[(da)], (r) * s[(da)] }
+#define  SET_NORMAL(x, y, z) do { \
+   normal[0] = (x); normal[1] = (y); normal[2] = (z); \
+} while(0)
+
+#define  GEAR_VERT(v, point, sign) vert((v), p[(point)].x, p[(point)].y, (sign) * width * 0.5, normal)
+
+#define START_STRIP do { \
+   gear->strips[cur_strip].first = v - gear->vertices; \
+} while(0);
+
+#define END_STRIP do { \
+   int _tmp = (v - gear->vertices); \
+   gear->strips[cur_strip].count = _tmp - gear->strips[cur_strip].first; \
+   cur_strip++; \
+} while (0)
+
+#define QUAD_WITH_NORMAL(p1, p2) do { \
+   SET_NORMAL((p[(p1)].y - p[(p2)].y), -(p[(p1)].x - p[(p2)].x), 0); \
+   v = GEAR_VERT(v, (p1), -1); \
+   v = GEAR_VERT(v, (p1), 1); \
+   v = GEAR_VERT(v, (p2), -1); \
+   v = GEAR_VERT(v, (p2), 1); \
+} while(0)
+
+      struct point {
+         GLfloat x;
+         GLfloat y;
+      };
+
+      /* Create the 7 points (only x,y coords) used to draw a tooth */
+      struct point p[7] = {
+         GEAR_POINT(r2, 1), // 0
+         GEAR_POINT(r2, 2), // 1
+         GEAR_POINT(r1, 0), // 2
+         GEAR_POINT(r1, 3), // 3
+         GEAR_POINT(r0, 0), // 4
+         GEAR_POINT(r1, 4), // 5
+         GEAR_POINT(r0, 4), // 6
+      };
+
+      /* Front face */
+      START_STRIP;
+      SET_NORMAL(0, 0, 1.0);
+      v = GEAR_VERT(v, 0, +1);
+      v = GEAR_VERT(v, 1, +1);
+      v = GEAR_VERT(v, 2, +1);
+      v = GEAR_VERT(v, 3, +1);
+      v = GEAR_VERT(v, 4, +1);
+      v = GEAR_VERT(v, 5, +1);
+      v = GEAR_VERT(v, 6, +1);
+      END_STRIP;
+
+      /* Inner face */
+      START_STRIP;
+      QUAD_WITH_NORMAL(4, 6);
+      END_STRIP;
+
+      /* Back face */
+      START_STRIP;
+      SET_NORMAL(0, 0, -1.0);
+      v = GEAR_VERT(v, 6, -1);
+      v = GEAR_VERT(v, 5, -1);
+      v = GEAR_VERT(v, 4, -1);
+      v = GEAR_VERT(v, 3, -1);
+      v = GEAR_VERT(v, 2, -1);
+      v = GEAR_VERT(v, 1, -1);
+      v = GEAR_VERT(v, 0, -1);
+      END_STRIP;
+
+      /* Outer face */
+      START_STRIP;
+      QUAD_WITH_NORMAL(0, 2);
+      END_STRIP;
+
+      START_STRIP;
+      QUAD_WITH_NORMAL(1, 0);
+      END_STRIP;
+
+      START_STRIP;
+      QUAD_WITH_NORMAL(3, 1);
+      END_STRIP;
+
+      START_STRIP;
+      QUAD_WITH_NORMAL(5, 3);
+      END_STRIP;
+   }
+
+   gear->nvertices = (v - gear->vertices);
+
+   /* Store the vertices in a vertex buffer object (VBO) */
+   glGenBuffers(1, &gear->vbo);
+   glBindBuffer(GL_ARRAY_BUFFER, gear->vbo);
+   glBufferData(GL_ARRAY_BUFFER, gear->nvertices * sizeof(GearVertex), gear->vertices, GL_STATIC_DRAW);
+
+   debugNetPrintf(INFO,"gear at: %p\n", gear);
+   return gear;
+}
+
+/** 
+ * Multiplies two 4x4 matrices.
+ * 
+ * The result is stored in matrix m.
+ * 
+ * @param m the first matrix to multiply
+ * @param n the second matrix to multiply
+ */
+static void
+multiply(GLfloat *m, const GLfloat *n)
+{
+   GLfloat tmp[16];
+   const GLfloat *row, *column;
+   div_t d;
+   int i, j;
+
+   for (i = 0; i < 16; i++) {
+      tmp[i] = 0;
+      d = div(i, 4);
+      row = n + d.quot * 4;
+      column = m + d.rem;
+      for (j = 0; j < 4; j++)
+         tmp[i] += row[j] * column[j * 4];
+   }
+   memcpy(m, &tmp, sizeof tmp);
+}
+
+/** 
+ * Rotates a 4x4 matrix.
+ * 
+ * @param[in,out] m the matrix to rotate
+ * @param angle the angle to rotate
+ * @param x the x component of the direction to rotate to
+ * @param y the y component of the direction to rotate to
+ * @param z the z component of the direction to rotate to
+ */
+static void
+rotate(GLfloat *m, GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
+{
+   double s, c;
+/*sincos(angle, &s, &c);*/
+   s = sin(angle);
+   c = cos(angle);
+   
+   GLfloat r[16] = {
+      x * x * (1 - c) + c,     y * x * (1 - c) + z * s, x * z * (1 - c) - y * s, 0,
+      x * y * (1 - c) - z * s, y * y * (1 - c) + c,     y * z * (1 - c) + x * s, 0, 
+      x * z * (1 - c) + y * s, y * z * (1 - c) - x * s, z * z * (1 - c) + c,     0,
+      0, 0, 0, 1
+   };
+
+   multiply(m, r);
+}
+
+
+/** 
+ * Translates a 4x4 matrix.
+ * 
+ * @param[in,out] m the matrix to translate
+ * @param x the x component of the direction to translate to
+ * @param y the y component of the direction to translate to
+ * @param z the z component of the direction to translate to
+ */
+static void
+translate(GLfloat *m, GLfloat x, GLfloat y, GLfloat z)
+{
+   GLfloat t[16] = { 1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0,  x, y, z, 1 };
+
+   multiply(m, t);
+}
+
+/** 
+ * Creates an identity 4x4 matrix.
+ * 
+ * @param m the matrix make an identity matrix
+ */
+static void
+identity(GLfloat *m)
+{
+   GLfloat t[16] = {
+      1.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0,
+   };
+
+   memcpy(m, t, sizeof(t));
+}
+
+/** 
+ * Transposes a 4x4 matrix.
+ *
+ * @param m the matrix to transpose
+ */
+static void 
+transpose(GLfloat *m)
+{
+   GLfloat t[16] = {
+      m[0], m[4], m[8],  m[12],
+      m[1], m[5], m[9],  m[13],
+      m[2], m[6], m[10], m[14],
+      m[3], m[7], m[11], m[15]};
+
+   memcpy(m, t, sizeof(t));
+}
+
+/**
+ * Inverts a 4x4 matrix.
+ *
+ * This function can currently handle only pure translation-rotation matrices.
+ * Read http://www.gamedev.net/community/forums/topic.asp?topic_id=425118
+ * for an explanation.
+ */
+static void
+invert(GLfloat *m)
+{
+   GLfloat t[16];
+   identity(t);
+
+   // Extract and invert the translation part 't'. The inverse of a
+   // translation matrix can be calculated by negating the translation
+   // coordinates.
+   t[12] = -m[12]; t[13] = -m[13]; t[14] = -m[14];
+
+   // Invert the rotation part 'r'. The inverse of a rotation matrix is
+   // equal to its transpose.
+   m[12] = m[13] = m[14] = 0;
+   transpose(m);
+
+   // inv(m) = inv(r) * inv(t)
+   multiply(m, t);
+}
+
+/** 
+ * Calculate a perspective projection transformation.
+ * 
+ * @param m the matrix to save the transformation in
+ * @param fovy the field of view in the y direction
+ * @param aspect the view aspect ratio
+ * @param zNear the near clipping plane
+ * @param zFar the far clipping plane
+ */
+void perspective(GLfloat *m, GLfloat fovy, GLfloat aspect, GLfloat zNear, GLfloat zFar)
+{
+   GLfloat tmp[16];
+   identity(tmp);
+
+   double sine, cosine, cotangent, deltaZ;
+   GLfloat radians = fovy / 2 * M_PI / 180;
+
+   deltaZ = zFar - zNear;
+   //sincos(radians, &sine, &cosine);
+   sine   = sin(radians);
+   cosine = cos(radians);
+
+   if ((deltaZ == 0) || (sine == 0) || (aspect == 0))
+      return;
+
+   cotangent = cosine / sine;
+
+   tmp[0] = cotangent / aspect;
+   tmp[5] = cotangent;
+   tmp[10] = -(zFar + zNear) / deltaZ;
+   tmp[11] = -1;
+   tmp[14] = -2 * zNear * zFar / deltaZ;
+   tmp[15] = 0;
+
+   memcpy(m, tmp, sizeof(tmp));
+}
+
+/**
+ * Draws a gear.
+ *
+ * @param gear the gear to draw
+ * @param transform the current transformation matrix
+ * @param x the x position to draw the gear at
+ * @param y the y position to draw the gear at
+ * @param angle the rotation angle of the gear
+ * @param color the color of the gear
+ */
+static void
+draw_gear(struct gear *gear, GLfloat *transform,
+      GLfloat x, GLfloat y, GLfloat angle, const GLfloat color[4])
+{
+   GLfloat model_view[16];
+   GLfloat normal_matrix[16];
+   GLfloat model_view_projection[16];
+
+   /* Translate and rotate the gear */
+   memcpy(model_view, transform, sizeof (model_view));
+   translate(model_view, x, y, 0);
+   rotate(model_view, 2 * M_PI * angle / 360.0, 0, 0, 1);
+
+   /* Create and set the ModelViewProjectionMatrix */
+   memcpy(model_view_projection, ProjectionMatrix, sizeof(model_view_projection));
+   multiply(model_view_projection, model_view);
+
+   glUniformMatrix4fv(ModelViewProjectionMatrix_location, 1, GL_FALSE,
+                      model_view_projection);
+
+   /* 
+    * Create and set the NormalMatrix. It's the inverse transpose of the
+    * ModelView matrix.
+    */
+   memcpy(normal_matrix, model_view, sizeof (normal_matrix));
+   invert(normal_matrix);
+   transpose(normal_matrix);
+   glUniformMatrix4fv(NormalMatrix_location, 1, GL_FALSE, normal_matrix);
+
+   /* Set the gear color */
+   glUniform4fv(MaterialColor_location, 1, color);
+
+   /* Set the vertex buffer object to use */
+   glBindBuffer(GL_ARRAY_BUFFER, gear->vbo);
+
+   /* Set up the position of the attributes in the vertex buffer object */
+   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE,
+         6 * sizeof(GLfloat), NULL);
+   glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE,
+         6 * sizeof(GLfloat), (GLfloat *) 0 + 3);
+
+   /* Enable the attributes */
+   glEnableVertexAttribArray(0);
+   glEnableVertexAttribArray(1);
+
+   /* Draw the triangle strips that comprise the gear */
+   int n;
+   for (n = 0; n < gear->nstrips; n++)
+      glDrawArrays(GL_TRIANGLE_STRIP, gear->strips[n].first, gear->strips[n].count);
+
+   /* Disable the attributes */
+   glDisableVertexAttribArray(1);
+   glDisableVertexAttribArray(0);
+}
+
+/** 
+ * Draws the gears.
+ */
+void
+gears_draw(void)
+{
+   const static GLfloat red[4] = { 0.8, 0.1, 0.0, 1.0 };
+   const static GLfloat green[4] = { 0.0, 0.8, 0.2, 1.0 };
+   const static GLfloat blue[4] = { 0.2, 0.2, 1.0, 1.0 };
+   GLfloat transform[16];
+   identity(transform);
+
+   glClearColor(0.0, 0.0, 0.0, 1.0);
+   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+   /* Translate and rotate the view */
+   translate(transform, 0, 0, -20);
+   rotate(transform, 2 * M_PI * view_rot[0] / 360.0, 1, 0, 0);
+   rotate(transform, 2 * M_PI * view_rot[1] / 360.0, 0, 1, 0);
+   rotate(transform, 2 * M_PI * view_rot[2] / 360.0, 0, 0, 1);
+
+   /* Draw the gears */
+   draw_gear(gear1, transform, -3.0, -2.0, angle,             red  );
+   draw_gear(gear2, transform,  3.1, -2.0, -2 * angle - 9.0,  green);
+   draw_gear(gear3, transform, -3.1,  4.2, -2 * angle - 25.0, blue );
+   // debugNetPrintf(INFO,"[ORBIS_GL] Draw the gears\n");
+}
+
+/** 
+ * Handles a new window size or exposure.
+ * 
+ * @param width the window width
+ * @param height the window height
+ */
+void
+gears_reshape(int width, int height)
+{
+   /* Update the projection matrix */
+   perspective(ProjectionMatrix, 60.0, width / (float)height, 1.0, 1024.0);
+
+   /* Set the viewport */
+   glViewport(0, 0, (GLint) width, (GLint) height);
+}
+
+/** 
+ * Handles special eglut events.
+ * 
+ * @param special the event to handle.
+ */
+/*static void
+gears_special(int special)
+{
+   switch (special) {
+      case EGLUT_KEY_LEFT:
+         view_rot[1] += 5.0;
+         break;
+      case EGLUT_KEY_RIGHT:
+         view_rot[1] -= 5.0;
+         break;
+      case EGLUT_KEY_UP:
+         view_rot[0] += 5.0;
+         break;
+      case EGLUT_KEY_DOWN:
+         view_rot[0] -= 5.0;
+         break;
+   }
+}*/
+
+static int frames = 0;
+void
+gears_idle(int unused)
+{
+   //static int frames = 0;
+   static double tRot0 = -1.0, tRate0 = -1.0;
+   double dt;
+   double t = 0.005; // XXX eglutGet(EGLUT_ELAPSED_TIME) / 1000.0;
+
+   if (tRot0 < 0.0)
+      tRot0 = t;
+   dt = t - tRot0;
+   tRot0 = t;
+
+// hack (no time)
+    dt = frames;
+
+   /* advance rotation for next frame */
+   angle += 70.0 * dt;  /* 70 degrees per second */
+   if (angle > 3600.0)
+      angle -= 3600.0;
+
+debugNetPrintf(ERROR,"angle %3.1f %d\n", angle, frames);
+
+   //eglutPostRedisplay();
+   frames++;
+
+   if (tRate0 < 0.0)
+      tRate0 = t;
+   if (t - tRate0 >= 5.0) {
+      GLfloat seconds = t - tRate0;
+      GLfloat fps = frames / seconds;
+      debugNetPrintf(ERROR,"%d frames in %3.1f seconds = %6.3f FPS\n", frames, seconds,
+            fps);
+      tRate0 = t;
+      //frames = 0;
+   }
+}
+
+static const char vertex_shader[] =
+"attribute vec3 position;\n"
+"attribute vec3 normal;\n"
+"\n"
+"uniform mat4 ModelViewProjectionMatrix;\n"
+"uniform mat4 NormalMatrix;\n"
+"uniform vec4 LightSourcePosition;\n"
+"uniform vec4 MaterialColor;\n"
+"\n"
+"varying vec4 Color;\n"
+"\n"
+"void main(void)\n"
+"{\n"
+"    // Transform the normal to eye coordinates\n"
+"    vec3 N = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));\n"
+"\n"
+"    // The LightSourcePosition is actually its direction for directional light\n"
+"    vec3 L = normalize(LightSourcePosition.xyz);\n"
+"\n"
+"    // Multiply the diffuse value by the vertex color (which is fixed in this case)\n"
+"    // to get the actual color that we will use to draw this vertex with\n"
+"    float diffuse = max(dot(N, L), 0.0);\n"
+"    Color = diffuse * MaterialColor;\n"
+"\n"
+"    // Transform the position to clip coordinates\n"
+"    gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);\n"
+"}";
+
+static const char fragment_shader[] =
+"precision mediump float;\n"
+"varying vec4 Color;\n"
+"\n"
+"void main(void)\n"
+"{\n"
+"    gl_FragColor = Color;\n"
+"}";
+
+static void
+gears_init(void)
+{
+   GLuint v, f, program;
+   const char *p;
+   char msg[512];
+
+   glEnable(GL_CULL_FACE);
+   glEnable(GL_DEPTH_TEST);
+
+   /* Compile the vertex shader */
+   p = vertex_shader;
+   v = glCreateShader(GL_VERTEX_SHADER);
+   glShaderSource(v, 1, &p, NULL);
+   glCompileShader(v);
+   glGetShaderInfoLog(v, sizeof msg, NULL, msg);
+   debugNetPrintf(ERROR,"vertex shader info: %s\n", msg);
+
+   /* Compile the fragment shader */
+   p = fragment_shader;
+   f = glCreateShader(GL_FRAGMENT_SHADER);
+   glShaderSource(f, 1, &p, NULL);
+   glCompileShader(f);
+   glGetShaderInfoLog(f, sizeof msg, NULL, msg);
+   debugNetPrintf(ERROR,"fragment shader info: %s\n", msg);
+
+   /* Create and link the shader program */
+   program = glCreateProgram();
+   glAttachShader(program, v);
+   glAttachShader(program, f);
+   glBindAttribLocation(program, 0, "position");
+   glBindAttribLocation(program, 1, "normal");
+
+   glLinkProgram(program);
+   int ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glLinkProgram() failed: 0x%08X\n", ret);
+	}
+
+   glGetProgramInfoLog(program, sizeof msg, NULL, msg);
+   debugNetPrintf(INFO,"info: %s\n", msg);
+
+   /* Enable the shaders */
+   debugNetPrintf(INFO,"glUseProgram\n");
+   glUseProgram(program);
+   ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glUseProgram failed: 0x%08X\n", ret);
+	}
+
+   /* Get the locations of the uniforms so we can access them */
+   ModelViewProjectionMatrix_location = glGetUniformLocation(program, "ModelViewProjectionMatrix");
+   NormalMatrix_location = glGetUniformLocation(program, "NormalMatrix");
+   LightSourcePosition_location = glGetUniformLocation(program, "LightSourcePosition");
+   MaterialColor_location = glGetUniformLocation(program, "MaterialColor");
+
+   /* Set the LightSourcePosition uniform which is constant throught the program */
+   glUniform4fv(LightSourcePosition_location, 1, LightSourcePosition);
+
+debugNetPrintf(INFO,"[ORBIS_GL] making gears\n");
+   /* make the gears */
+   gear1 = create_gear(1.0, 4.0, 1.0, 20, 0.7);
+   gear2 = create_gear(0.5, 2.0, 2.0, 10, 0.7);
+   gear3 = create_gear(1.3, 2.0, 0.5, 10, 0.7);
+}
+
+int
+test(int argc, char *argv[])
+{
+   /* Initialize the window 
+   eglutInitWindowSize(300, 300);
+   eglutInitAPIMask(EGLUT_OPENGL_ES2_BIT);
+   eglutInit(argc, argv);*/
+
+   //eglutCreateWindow("es2gears");
+
+   /* Set up eglut callback functions 
+   eglutIdleFunc(gears_idle);
+   eglutReshapeFunc(gears_reshape);
+   eglutDisplayFunc(gears_draw);
+   eglutSpecialFunc(gears_special);*/
+
+   /* Initialize the gears */
+   gears_init();
+   
+   gears_reshape(1920, 1080);
+
+   //eglutMainLoop();
+
+   return 0;
+}

--- a/orbis_es2gears/source/es2gears.c
+++ b/orbis_es2gears/source/es2gears.c
@@ -101,15 +101,15 @@ static GLfloat ProjectionMatrix[16];
 /** The direction of the directional light for the scene */
 static const GLfloat LightSourcePosition[4] = { 5.0, 5.0, 10.0, 1.0};
 
-/** 
+/**
  * Fills a gear vertex.
- * 
+ *
  * @param v the vertex to fill
  * @param x the x coordinate
  * @param y the y coordinate
  * @param z the z coortinate
  * @param n pointer to the normal table 
- * 
+ *
  * @return the operation error code
  */
 static GearVertex *
@@ -127,13 +127,13 @@ vert(GearVertex *v, GLfloat x, GLfloat y, GLfloat z, GLfloat n[3])
 
 /**
  *  Create a gear wheel.
- * 
+ *
  *  @param inner_radius radius of hole at center
  *  @param outer_radius radius at center of teeth
  *  @param width width of gear
  *  @param teeth number of teeth
  *  @param tooth_depth depth of tooth
- *  
+ *
  *  @return pointer to the constructed struct gear
  */
 static struct gear *
@@ -176,7 +176,7 @@ create_gear(GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
       s[2] = sin(i * 2.0 * M_PI / teeth + da * 2);  c[2] = cos(i * 2.0 * M_PI / teeth + da * 2);
       s[3] = sin(i * 2.0 * M_PI / teeth + da * 3);  c[3] = cos(i * 2.0 * M_PI / teeth + da * 3);
       s[4] = sin(i * 2.0 * M_PI / teeth + da * 4);  c[4] = cos(i * 2.0 * M_PI / teeth + da * 4);
-      
+
       /*
       sincos(i * 2.0 * M_PI / teeth, &s[0], &c[0]);
       sincos(i * 2.0 * M_PI / teeth + da, &s[1], &c[1]);
@@ -284,11 +284,11 @@ create_gear(GLfloat inner_radius, GLfloat outer_radius, GLfloat width,
    return gear;
 }
 
-/** 
+/*
  * Multiplies two 4x4 matrices.
- * 
+ *
  * The result is stored in matrix m.
- * 
+ *
  * @param m the first matrix to multiply
  * @param n the second matrix to multiply
  */
@@ -311,9 +311,9 @@ multiply(GLfloat *m, const GLfloat *n)
    memcpy(m, &tmp, sizeof tmp);
 }
 
-/** 
+/*
  * Rotates a 4x4 matrix.
- * 
+ *
  * @param[in,out] m the matrix to rotate
  * @param angle the angle to rotate
  * @param x the x component of the direction to rotate to
@@ -324,10 +324,9 @@ static void
 rotate(GLfloat *m, GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
 {
    double s, c;
-/*sincos(angle, &s, &c);*/
    s = sin(angle);
    c = cos(angle);
-   
+
    GLfloat r[16] = {
       x * x * (1 - c) + c,     y * x * (1 - c) + z * s, x * z * (1 - c) - y * s, 0,
       x * y * (1 - c) - z * s, y * y * (1 - c) + c,     y * z * (1 - c) + x * s, 0, 
@@ -355,9 +354,9 @@ translate(GLfloat *m, GLfloat x, GLfloat y, GLfloat z)
    multiply(m, t);
 }
 
-/** 
+/**
  * Creates an identity 4x4 matrix.
- * 
+ *
  * @param m the matrix make an identity matrix
  */
 static void
@@ -373,7 +372,7 @@ identity(GLfloat *m)
    memcpy(m, t, sizeof(t));
 }
 
-/** 
+/**
  * Transposes a 4x4 matrix.
  *
  * @param m the matrix to transpose
@@ -417,9 +416,9 @@ invert(GLfloat *m)
    multiply(m, t);
 }
 
-/** 
+/**
  * Calculate a perspective projection transformation.
- * 
+ *
  * @param m the matrix to save the transformation in
  * @param fovy the field of view in the y direction
  * @param aspect the view aspect ratio
@@ -484,7 +483,7 @@ draw_gear(struct gear *gear, GLfloat *transform,
    glUniformMatrix4fv(ModelViewProjectionMatrix_location, 1, GL_FALSE,
                       model_view_projection);
 
-   /* 
+   /*
     * Create and set the NormalMatrix. It's the inverse transpose of the
     * ModelView matrix.
     */
@@ -519,7 +518,7 @@ draw_gear(struct gear *gear, GLfloat *transform,
    glDisableVertexAttribArray(0);
 }
 
-/** 
+/**
  * Draws the gears.
  */
 void
@@ -544,12 +543,11 @@ gears_draw(void)
    draw_gear(gear1, transform, -3.0, -2.0, angle,             red  );
    draw_gear(gear2, transform,  3.1, -2.0, -2 * angle - 9.0,  green);
    draw_gear(gear3, transform, -3.1,  4.2, -2 * angle - 25.0, blue );
-   // debugNetPrintf(INFO,"[ORBIS_GL] Draw the gears\n");
 }
 
-/** 
+/**
  * Handles a new window size or exposure.
- * 
+ *
  * @param width the window width
  * @param height the window height
  */
@@ -563,35 +561,36 @@ gears_reshape(int width, int height)
    glViewport(0, 0, (GLint) width, (GLint) height);
 }
 
-/** 
+/**
  * Handles special eglut events.
- * 
+ *
  * @param special the event to handle.
  */
-/*static void
+void
 gears_special(int special)
 {
    switch (special) {
-      case EGLUT_KEY_LEFT:
+      case 0: //EGLUT_KEY_LEFT:
          view_rot[1] += 5.0;
          break;
-      case EGLUT_KEY_RIGHT:
+      case 1: //EGLUT_KEY_RIGHT:
          view_rot[1] -= 5.0;
          break;
-      case EGLUT_KEY_UP:
+      case 2: //EGLUT_KEY_UP:
          view_rot[0] += 5.0;
          break;
-      case EGLUT_KEY_DOWN:
+      case 3: //EGLUT_KEY_DOWN:
          view_rot[0] -= 5.0;
          break;
    }
-}*/
+}
 
+// hack (no time)
 static int frames = 0;
+
 void
-gears_idle(int unused)
+gears_idle(int *flag)
 {
-   //static int frames = 0;
    static double tRot0 = -1.0, tRate0 = -1.0;
    double dt;
    double t = 0.005; // XXX eglutGet(EGLUT_ELAPSED_TIME) / 1000.0;
@@ -601,15 +600,16 @@ gears_idle(int unused)
    dt = t - tRot0;
    tRot0 = t;
 
-// hack (no time)
-    dt = frames;
+   // hack (no time)
+   dt = frames;
 
    /* advance rotation for next frame */
    angle += 70.0 * dt;  /* 70 degrees per second */
    if (angle > 3600.0)
       angle -= 3600.0;
 
-debugNetPrintf(ERROR,"angle %3.1f %d\n", angle, frames);
+   if (frames%1000 == 0)
+      debugNetPrintf(INFO,"angle %3.1f %d\n", angle, frames);
 
    //eglutPostRedisplay();
    frames++;
@@ -698,9 +698,9 @@ gears_init(void)
 
    glLinkProgram(program);
    int ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glLinkProgram() failed: 0x%08X\n", ret);
-	}
+   if (ret) {
+     debugNetPrintf(ERROR,"[ORBIS_GL] glLinkProgram() failed: 0x%08X\n", ret);
+   }
 
    glGetProgramInfoLog(program, sizeof msg, NULL, msg);
    debugNetPrintf(INFO,"info: %s\n", msg);
@@ -709,9 +709,9 @@ gears_init(void)
    debugNetPrintf(INFO,"glUseProgram\n");
    glUseProgram(program);
    ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glUseProgram failed: 0x%08X\n", ret);
-	}
+   if (ret) {
+     debugNetPrintf(ERROR,"[ORBIS_GL] glUseProgram failed: 0x%08X\n", ret);
+   }
 
    /* Get the locations of the uniforms so we can access them */
    ModelViewProjectionMatrix_location = glGetUniformLocation(program, "ModelViewProjectionMatrix");
@@ -730,16 +730,16 @@ debugNetPrintf(INFO,"[ORBIS_GL] making gears\n");
 }
 
 int
-test(int argc, char *argv[])
+es2gears_init(int argc, char *argv[])
 {
-   /* Initialize the window 
+   /* Initialize the window
    eglutInitWindowSize(300, 300);
    eglutInitAPIMask(EGLUT_OPENGL_ES2_BIT);
    eglutInit(argc, argv);*/
 
    //eglutCreateWindow("es2gears");
 
-   /* Set up eglut callback functions 
+   /* Set up eglut callback functions
    eglutIdleFunc(gears_idle);
    eglutReshapeFunc(gears_reshape);
    eglutDisplayFunc(gears_draw);
@@ -747,10 +747,9 @@ test(int argc, char *argv[])
 
    /* Initialize the gears */
    gears_init();
-   
+
    gears_reshape(ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT);
 
    //eglutMainLoop();
-
    return 0;
 }

--- a/orbis_es2gears/source/main.c
+++ b/orbis_es2gears/source/main.c
@@ -11,7 +11,8 @@
 #include <modplayer.h>
 #include <ps4link.h>
 #include <debugnet.h>
-#include <piglet.h>
+
+#include <orbisGl.h>
 #include <unistd.h>
 
 Orbis2dConfig *conf;
@@ -28,9 +29,6 @@ typedef struct OrbisGlobalConf
 }OrbisGlobalConf;
 
 OrbisGlobalConf *myConf;
-
-#define RENDER_WIDTH  1920
-#define RENDER_HEIGHT 1080
 
 static EGLDisplay s_display = EGL_NO_DISPLAY;
 static EGLSurface s_surface = EGL_NO_SURFACE;
@@ -540,6 +538,34 @@ err:
 	return false;
 }
 
+////
+bool initAppGl()
+{
+	int ret;
+	ret=orbisGlInit(ATTR_ORBISGL_WIDTH,ATTR_ORBISGL_HEIGHT);
+	if(ret>0)
+	{
+			glViewport(0, 0, ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT);
+			ret=glGetError();
+			if(ret)
+			{
+				debugNetPrintf(ERROR,"[ORBISGLPERF] glViewport failed: 0x%08X\n",ret);
+				return false;
+			}
+			glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+			ret=glGetError();
+			if(ret)
+			{
+				debugNetPrintf(ERROR,"[ORBISGLPERF] glClearColor failed: 0x%08X\n",ret);
+				return false;
+			}
+			return true;
+	}
+	return false;
+}
+
+
+
 /// main loop for gears
 int frame = 0;
 static bool main_loop2(void) {
@@ -695,7 +721,7 @@ int main(int argc, char *argv[])
 		goto err;
 	}
 
-	if(!create_context(RENDER_WIDTH, RENDER_HEIGHT)) 
+	if(!create_context(ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT)) 
 	{
 		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create context.\n");
 		goto err;
@@ -718,7 +744,7 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	glViewport(0, 0, RENDER_WIDTH, RENDER_HEIGHT);
+	glViewport(0, 0, ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT);
 	ret = glGetError();
 	if(ret)
 	{

--- a/orbis_es2gears/source/main.c
+++ b/orbis_es2gears/source/main.c
@@ -1,0 +1,766 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <kernel.h>
+#include <systemservice.h>
+#include <orbis2d.h>
+#include <orbisPad.h>
+#include <orbisKeyboard.h>
+#include <orbisAudio.h>
+#include <modplayer.h>
+#include <ps4link.h>
+#include <debugnet.h>
+#include <piglet.h>
+#include <unistd.h>
+
+Orbis2dConfig *conf;
+OrbisPadConfig *confPad;
+
+typedef struct OrbisGlobalConf
+{
+	Orbis2dConfig *conf;
+	OrbisPadConfig *confPad;
+	OrbisAudioConfig *confAudio;
+	OrbisKeyboardConfig *confKeyboard;
+	ps4LinkConfiguration *confLink;
+	int orbisLinkFlag;
+}OrbisGlobalConf;
+
+OrbisGlobalConf *myConf;
+
+#define RENDER_WIDTH  1920
+#define RENDER_HEIGHT 1080
+
+static EGLDisplay s_display = EGL_NO_DISPLAY;
+static EGLSurface s_surface = EGL_NO_SURFACE;
+static EGLContext s_context = EGL_NO_CONTEXT;
+
+static GLuint s_texture_id = 0;
+static GLuint s_program_id = 0;
+
+static GLint s_xyz_loc;
+static GLint s_uv_loc;
+static GLint s_sampler_loc;
+
+static const GLfloat s_obj_vertices[] = {
+	-0.5f, 0.5f, 0.0f,  /* XYZ #0 */
+	 0.0f, 0.0f,        /* UV  #0 */
+	-0.5f, -0.5f, 0.0f, /* XYZ #1 */
+	 0.0f,  1.0f,       /* UV  #1 */
+	 0.5f, -0.5f, 0.0f, /* XYZ #2 */
+	 1.0f,  1.0f,       /* UV  #2 */
+	 0.5f,  0.5f, 0.0f, /* XYZ #3 */
+	 1.0f,  0.0f        /* UV  #3 */
+};
+static const GLushort s_obj_indices[] = {
+	0, 1, 2, 0, 2, 3,
+};
+
+static const GLubyte s_texture_data[4 * 3] = {
+	255, 0, 0,   /* red */
+	0, 255, 0,   /* green */
+	0, 0, 255,   /* blue */
+	255, 255, 0, /* yellow */
+};
+
+static const GLchar s_vertex_shader_code[] =
+	"attribute vec4 a_xyz;\n"
+	"attribute vec2 a_uv;\n"
+	"varying vec2 v_uv;\n"
+	"\n"
+	"void main() {\n"
+	"	gl_Position = a_xyz;\n"
+	"	v_uv = a_uv;\n"
+	"}\n";
+
+static const GLchar s_fragment_shader_code[] =
+	"precision mediump float;\n"
+	"varying vec2 v_uv;\n"
+	"uniform sampler2D s_texture;\n"
+	"\n"
+	"void main() {\n"
+	"	gl_FragColor = texture2D(s_texture, v_uv);\n"
+"}\n";
+
+
+
+static bool create_context(unsigned int width, unsigned int height) 
+{
+	ScePglConfig pgl_config;
+	SceWindow render_window = { 0, width, height };
+	EGLConfig config = NULL;
+	EGLint num_configs;
+
+	EGLint attribs[] = {
+		EGL_RED_SIZE, 8,
+		EGL_GREEN_SIZE, 8,
+		EGL_BLUE_SIZE, 8,
+		EGL_ALPHA_SIZE, 8,
+		EGL_DEPTH_SIZE, 0,
+		EGL_STENCIL_SIZE, 0,
+		EGL_SAMPLE_BUFFERS, 0,
+		EGL_SAMPLES, 0,
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_NONE,
+	};
+
+	EGLint ctx_attribs[] = {
+		EGL_CONTEXT_CLIENT_VERSION, 2,
+		EGL_NONE,
+	};
+
+	EGLint window_attribs[] = {
+		EGL_RENDER_BUFFER, EGL_BACK_BUFFER,
+		EGL_NONE,
+	};
+
+	int major, minor;
+	int ret;
+
+	memset(&pgl_config, 0, sizeof(pgl_config));
+	{
+		pgl_config.size = sizeof(pgl_config);
+		pgl_config.flags = SCE_PGL_FLAGS_USE_COMPOSITE_EXT | SCE_PGL_FLAGS_USE_FLEXIBLE_MEMORY | 0x60;
+		pgl_config.processOrder = 1;
+		pgl_config.systemSharedMemorySize = 0x200000;
+		pgl_config.videoSharedMemorySize = 0x2400000;
+		pgl_config.maxMappedFlexibleMemory = 0xAA00000;
+		pgl_config.drawCommandBufferSize = 0xC0000;
+		pgl_config.lcueResourceBufferSize = 0x10000;
+		pgl_config.dbgPosCmd_0x40 = 1920;
+		pgl_config.dbgPosCmd_0x44 = 1080;
+		pgl_config.dbgPosCmd_0x48 = 0;
+		pgl_config.dbgPosCmd_0x4C = 0;
+		pgl_config.unk_0x5C = 2;
+	}
+
+	if (!scePigletSetConfigurationVSH(&pgl_config)) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] scePigletSetConfigurationVSH failed.\n");
+		goto err;
+	}
+
+	s_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+	if (s_display == EGL_NO_DISPLAY) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglGetDisplay failed.\n");
+		goto err;
+	}
+	
+	
+    if (eglInitialize(s_display, &major, &minor) != EGL_TRUE)
+    {
+        ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglInitialize failed: 0x%08X\n", ret);
+		goto err;
+    }
+
+
+	/*if (!eglInitialize(s_display, &major, &minor)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglInitialize failed: 0x%08X\n", ret);
+		goto err;
+	}*/
+	debugNetPrintf(INFO,"[ORBIS_GL] EGL version major:%d, minor:%d\n", major, minor);
+
+	
+	if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglBindAPI failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	if (!eglSwapInterval(s_display, 0)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapInterval failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	if (!eglChooseConfig(s_display, attribs, &config, 1, &num_configs)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglChooseConfig failed: 0x%08X\n", ret);
+		goto err;
+	}
+	//debugNetPrintf(ERROR,"[ORBIS_GL] num_configs: %d\n", num_configs);
+	if (num_configs != 1) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] No available configuration found.\n");
+		goto err;
+	}
+
+	s_surface = eglCreateWindowSurface(s_display, config, &render_window, window_attribs);
+	if (s_surface == EGL_NO_SURFACE) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglCreateWindowSurface failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	s_context = eglCreateContext(s_display, config, EGL_NO_CONTEXT, ctx_attribs);
+	if (s_context == EGL_NO_CONTEXT) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglCreateContext failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	if (!eglMakeCurrent(s_display, s_surface, s_surface, s_context)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglMakeCurrent failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+    const char *s;
+    s = eglQueryString(s_display, EGL_VERSION);
+    debugNetPrintf(INFO,"EGL_VERSION: %s\n", s);
+    
+    s = eglQueryString(s_display, EGL_VENDOR);
+    debugNetPrintf(INFO,"EGL_VENDOR: %s\n", s);
+
+    s = eglQueryString(s_display, EGL_EXTENSIONS);
+    debugNetPrintf(INFO,"EGL_EXTENSIONS:\n", s);
+   //print_extension_list((char *) s);
+
+    s = eglQueryString(s_display, EGL_CLIENT_APIS);
+    debugNetPrintf(INFO,"EGL_CLIENT_APIS: %s\n", s);
+
+    debugNetPrintf(INFO,"GL_RENDERER   = %s\n", (char *) glGetString(GL_RENDERER));
+    debugNetPrintf(INFO,"GL_VERSION    = %s\n", (char *) glGetString(GL_VERSION));
+    debugNetPrintf(INFO,"GL_VENDOR     = %s\n", (char *) glGetString(GL_VENDOR));
+    debugNetPrintf(INFO,"GL_EXTENSIONS = %s\n", (char *) glGetString(GL_EXTENSIONS));
+    
+	return true;
+
+err:
+	return false;
+}
+
+static void destroy_context(void) {
+	int ret;
+
+	if (!eglDestroyContext(s_display, s_context)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglDestroyContext failed: 0x%08X\n", ret);
+	}
+	s_context = EGL_NO_CONTEXT;
+
+	if (!eglDestroySurface(s_display, s_surface)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglDestroySurface failed: 0x%08X\n", ret);
+	}
+	s_surface = EGL_NO_SURFACE;
+
+	if (!eglTerminate(s_display)) {
+		ret = eglGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] eglTerminate failed: 0x%08X\n", ret);
+	}
+	s_display = EGL_NO_DISPLAY;
+}
+
+static bool create_texture(void) {
+	int ret;
+
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glPixelStorei failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glGenTextures(1, &s_texture_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glGenTextures failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glBindTexture(GL_TEXTURE_2D, s_texture_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glBindTexture failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 2, 2, 0, GL_RGB, GL_UNSIGNED_BYTE, s_texture_data);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glTexImage2D failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glTexParameteri failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glTexParameteri failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+static bool destroy_texture(void) {
+	int ret;
+
+	glDeleteTextures(1, &s_texture_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteTextures failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+// vertex
+// shader
+static bool compile_shader(GLenum type, const char* source, size_t length, GLuint* pShader) {
+	GLuint shader;
+	GLint tmp_length = (int)length;
+	GLint success;
+	char log_buf[256];
+	int ret;
+
+	shader = glCreateShader(type);
+	if (!shader) {
+		ret = glGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] glCreateShader failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+    // shader from source
+	glShaderSource(shader, 1, &source, &tmp_length);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glShaderSource failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glCompileShader(shader);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glCompileShader failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glGetShaderiv failed: 0x%08X\n", ret);
+		goto err;
+	}
+	if (!success) {
+		glGetShaderInfoLog(shader, sizeof(log_buf), NULL, log_buf);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glGetShaderInfoLog failed: 0x%08X\n", ret);
+			goto err;
+		}
+		if (strlen(log_buf) > 1) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] shader compilation failed with log:\n%s\n", log_buf);
+		} else {
+			debugNetPrintf(ERROR,"[ORBIS_GL] shader compilation failed\n");
+		}
+		goto err;
+	}
+
+	if (pShader) {
+		*pShader = shader;
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+static bool create_program(void) {
+	GLuint vertex_shader_id = 0;
+	GLuint fragment_shader_id = 0;
+	GLuint program_id = 0;
+	GLint success;
+	char log[256];
+	int ret;
+
+	if (!compile_shader(GL_VERTEX_SHADER, s_vertex_shader_code, strlen(s_vertex_shader_code), &vertex_shader_id)) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to compile vertex shader.\n");
+		goto err;
+	}
+
+	if (!compile_shader(GL_FRAGMENT_SHADER, s_fragment_shader_code, strlen(s_fragment_shader_code), &fragment_shader_id)) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to compile fragment shader.\n");
+		goto err;
+	}
+
+
+/*// Program setup
+
+One you have successfully compiled the shader objects of interest, you can link them into a program. This begins by creating a program object via this command:
+GLuint glCreateProgram();
+*/
+// Vertex and fragment shaders are successfully compiled.
+// Now time to link them together into a program.
+// Get a program object.
+//GLuint program = glCreateProgram();
+	program_id = glCreateProgram();
+	if (!program_id) {
+		ret = glGetError();
+		debugNetPrintf(ERROR,"[ORBIS_GL] glCreateProgram failed: 0x%08X\n", ret);
+		goto err;
+	}
+/*
+After creating a program, the shader objects you wish to link to it must be attached to the program. This is done via this function:
+void glAttachShader(GLuint program​, GLuint shader​);
+*/
+
+// Attach our shaders to our program
+	glAttachShader(program_id, vertex_shader_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glAttachShader(vertex_shader) failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glAttachShader(program_id, fragment_shader_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glAttachShader(fragment_shader) failed: 0x%08X\n", ret);
+		goto err;
+	}
+// Link our program
+	glLinkProgram(program_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glLinkProgram() failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glGetProgramiv(program_id, GL_LINK_STATUS, &success);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glGetProgramiv() failed: 0x%08X\n", ret);
+		goto err;
+	}
+	if (!success) {
+		glGetProgramInfoLog(program_id, sizeof(log), NULL, log);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glGetProgramInfoLog failed: 0x%08X\n", ret);
+			goto err;
+		}
+		if (strlen(log) > 1) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] Unable to link shader program:\n%s\n", log);
+		} else {
+			debugNetPrintf(ERROR,"[ORBIS_GL] Unable to link shader program.\n");
+		}
+		goto err;
+	}
+
+// We don't need the program anymore.
+//	glDeleteProgram(program);
+	
+// Don't leak shaders either.
+	glDeleteShader(fragment_shader_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(fragment_shader) failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	glDeleteShader(vertex_shader_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(vertex_shader) failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	s_xyz_loc = glGetAttribLocation(program_id, "a_xyz");
+	s_uv_loc = glGetAttribLocation(program_id, "a_uv");
+	s_sampler_loc = glGetUniformLocation(program_id, "s_texture");
+
+	s_program_id = program_id;
+
+	return true;
+
+err:
+	if (program_id > 0) {
+		glDeleteProgram(program_id);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteProgram failed: 0x%08X\n", ret);
+			goto err;
+		}
+	}
+
+	if (fragment_shader_id > 0) {
+		glDeleteShader(fragment_shader_id);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(fragment_shader) failed: 0x%08X\n", ret);
+			goto err;
+		}
+		fragment_shader_id = 0;
+	}
+
+	if (vertex_shader_id > 0) {
+		glDeleteShader(vertex_shader_id);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(vertex_shader) failed: 0x%08X\n", ret);
+			goto err;
+		}
+		vertex_shader_id = 0;
+	}
+
+	return false;
+}
+
+static bool destroy_program(void) {
+	int ret;
+
+	glDeleteProgram(s_program_id);
+	ret = glGetError();
+	if (ret) {
+		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteProgram failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+/// main loop for gears
+int frame = 0;
+static bool main_loop2(void) {
+	int ret;
+
+	while (1)
+	{
+	    glClear(GL_COLOR_BUFFER_BIT);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glClear failed: 0x%08X\n", ret);
+			goto err;
+		}
+		
+		/// draw
+		gears_draw();
+		
+		gears_idle(frame);
+	    
+	    // flip frame
+	    if (!eglSwapBuffers(s_display, s_surface)) {
+			ret = eglGetError();
+			debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapBuffers failed: 0x%08X\n", ret);
+			goto err;
+		}
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+
+static bool main_loop(void) {
+	int ret;
+
+float i = 0.0;
+	while (1)
+	{
+	    /*if(i>256) i = 0.0;
+	    glClearColor(0.0f, i, i, 1.0f);
+	    debugNetPrintf(ERROR,"i: %.3f\n", i);
+	    i++;*/
+	    
+		glClear(GL_COLOR_BUFFER_BIT);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glClear failed: 0x%08X\n", ret);
+			goto err;
+		}
+		
+		//gears_draw();
+#if 1
+		glUseProgram(s_program_id);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glUseProgram failed: 0x%08X\n", ret);
+			goto err;
+		}
+//glVertexAttribPointer
+		glVertexAttribPointer(s_xyz_loc, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), s_obj_vertices);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glVertexAttribPointer failed: 0x%08X\n", ret);
+			goto err;
+		}
+		glVertexAttribPointer(s_uv_loc, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), &s_obj_vertices[3]);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glVertexAttribPointer failed: 0x%08X\n", ret);
+			goto err;
+		}
+
+// glEnableVertexAttribArray
+		glEnableVertexAttribArray(s_xyz_loc);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glEnableVertexAttribArray failed: 0x%08X\n", ret);
+			goto err;
+		}
+		glEnableVertexAttribArray(s_uv_loc);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glEnableVertexAttribArray failed: 0x%08X\n", ret);
+			goto err;
+		}
+
+//glActiveTexture
+		glActiveTexture(GL_TEXTURE0);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glActiveTexture failed: 0x%08X\n", ret);
+			goto err;
+		}
+		glBindTexture(GL_TEXTURE_2D, s_texture_id);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glBindTexture failed: 0x%08X\n", ret);
+			goto err;
+		}
+
+		glUniform1i(s_sampler_loc, 0);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glUniform1i failed: 0x%08X\n", ret);
+			goto err;
+		}
+
+		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, s_obj_indices);
+		ret = glGetError();
+		if (ret) {
+			debugNetPrintf(ERROR,"[ORBIS_GL] glDrawElements failed: 0x%08X\n", ret);
+			goto err;
+		}
+#endif
+		if (!eglSwapBuffers(s_display, s_surface)) {
+			ret = eglGetError();
+			debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapBuffers failed: 0x%08X\n", ret);
+			goto err;
+		}
+	}
+
+	return true;
+
+err:
+	return false;
+}
+
+
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+
+	uintptr_t intptr=0;
+	sscanf(argv[1],"%p",&intptr);
+	myConf=(OrbisGlobalConf *)intptr;
+	ret=ps4LinkInitWithConf(myConf->confLink);
+	if(!ret)
+	{
+		ps4LinkFinish();
+		return 0;
+	}
+	debugNetPrintf(INFO,"[ORBIS_GL] Hello from first gl es sample with hitodama's sdk and liborbis\n");	
+	sleep(1);
+
+	ret=sceSystemServiceHideSplashScreen();
+	if(ret) 
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] sceSystemServiceHideSplashScreen failed: 0x%08X\n", ret);
+		goto err;
+	}
+
+	if(!create_context(RENDER_WIDTH, RENDER_HEIGHT)) 
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create context.\n");
+		goto err;
+	}
+
+#if 0	
+/////	
+	if(!create_texture()) 
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create texture.\n");
+		goto err_destroy_context;
+	}
+
+////
+	if(!create_program())
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create shader program.\n");
+		//
+        goto err_destroy_texture;
+	}
+#endif
+
+	glViewport(0, 0, RENDER_WIDTH, RENDER_HEIGHT);
+	ret = glGetError();
+	if(ret)
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] glViewport failed: 0x%08X\n", ret);
+		goto err_destroy_program;
+	}
+
+	glClearColor(0.0f, 0.0f, 1.0f, 1.0f);  // blue
+	ret = glGetError();
+	if (ret) 
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] glClearColor failed: 0x%08X\n", ret);
+		goto err_destroy_program;
+	}
+
+#if 1
+debugNetPrintf(ERROR,"[ORBIS_GL] call test()\n");
+test();
+debugNetPrintf(ERROR,"[ORBIS_GL] after test()\n");
+#endif
+
+//goto err;  // force exit
+
+	if (!main_loop2()) 
+	{
+		debugNetPrintf(ERROR,"[ORBIS_GL] Main loop failed.\n");
+		goto err_destroy_program;
+	}
+
+	err_destroy_program:
+		destroy_program();
+
+	err_destroy_texture:
+		destroy_texture();
+
+	err_destroy_context:
+		destroy_context();
+
+	err:
+	
+	
+	ps4LinkFinish();
+	
+	exit(EXIT_SUCCESS);
+}

--- a/orbis_es2gears/source/main.c
+++ b/orbis_es2gears/source/main.c
@@ -1,3 +1,17 @@
+/*
+ * es2gears liborbisGl sample
+ * ---------------------------
+ *
+ * This is a liborbisGl port of es2gears, from mesa/demos package:
+ * https://github.com/freedesktop/mesa-demos/blob/master/src/egl/opengles2/es2gears.c
+ *
+ * whole EGL setup/cleanup is internally managed by liborbisGL;
+ * whole OpenGL ES 2.0 part in e2gears.c is basically left untouched (we have to replace GLUT, here not available);
+ * main render loop calls 3 gears_functions: draw, move and eventually update rotations by controller;
+ * all timing functions are actually removed, using framecount (hugly hack) to get animation computed and rendered;
+ * includes playing of .mod files and controller input;
+ * main skeleton results in a very basic and clean code.
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,11 +25,15 @@
 #include <modplayer.h>
 #include <ps4link.h>
 #include <debugnet.h>
-
+#include <orbisFile.h>
 #include <orbisGl.h>
 #include <unistd.h>
 
-Orbis2dConfig *conf;
+
+
+bool flag=true;
+
+Orbis2dConfig  *conf;
 OrbisPadConfig *confPad;
 
 typedef struct OrbisGlobalConf
@@ -30,516 +48,113 @@ typedef struct OrbisGlobalConf
 
 OrbisGlobalConf *myConf;
 
-static EGLDisplay s_display = EGL_NO_DISPLAY;
-static EGLSurface s_surface = EGL_NO_SURFACE;
-static EGLContext s_context = EGL_NO_CONTEXT;
-
-static GLuint s_texture_id = 0;
-static GLuint s_program_id = 0;
-
-static GLint s_xyz_loc;
-static GLint s_uv_loc;
-static GLint s_sampler_loc;
-
-static const GLfloat s_obj_vertices[] = {
-	-0.5f, 0.5f, 0.0f,  /* XYZ #0 */
-	 0.0f, 0.0f,        /* UV  #0 */
-	-0.5f, -0.5f, 0.0f, /* XYZ #1 */
-	 0.0f,  1.0f,       /* UV  #1 */
-	 0.5f, -0.5f, 0.0f, /* XYZ #2 */
-	 1.0f,  1.0f,       /* UV  #2 */
-	 0.5f,  0.5f, 0.0f, /* XYZ #3 */
-	 1.0f,  0.0f        /* UV  #3 */
-};
-static const GLushort s_obj_indices[] = {
-	0, 1, 2, 0, 2, 3,
-};
-
-static const GLubyte s_texture_data[4 * 3] = {
-	255, 0, 0,   /* red */
-	0, 255, 0,   /* green */
-	0, 0, 255,   /* blue */
-	255, 255, 0, /* yellow */
-};
-
-static const GLchar s_vertex_shader_code[] =
-	"attribute vec4 a_xyz;\n"
-	"attribute vec2 a_uv;\n"
-	"varying vec2 v_uv;\n"
-	"\n"
-	"void main() {\n"
-	"	gl_Position = a_xyz;\n"
-	"	v_uv = a_uv;\n"
-	"}\n";
-
-static const GLchar s_fragment_shader_code[] =
-	"precision mediump float;\n"
-	"varying vec2 v_uv;\n"
-	"uniform sampler2D s_texture;\n"
-	"\n"
-	"void main() {\n"
-	"	gl_FragColor = texture2D(s_texture, v_uv);\n"
-"}\n";
-
-
-
-static bool create_context(unsigned int width, unsigned int height) 
+void updateController()
 {
-	ScePglConfig pgl_config;
-	SceWindow render_window = { 0, width, height };
-	EGLConfig config = NULL;
-	EGLint num_configs;
-
-	EGLint attribs[] = {
-		EGL_RED_SIZE, 8,
-		EGL_GREEN_SIZE, 8,
-		EGL_BLUE_SIZE, 8,
-		EGL_ALPHA_SIZE, 8,
-		EGL_DEPTH_SIZE, 0,
-		EGL_STENCIL_SIZE, 0,
-		EGL_SAMPLE_BUFFERS, 0,
-		EGL_SAMPLES, 0,
-		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-		EGL_NONE,
-	};
-
-	EGLint ctx_attribs[] = {
-		EGL_CONTEXT_CLIENT_VERSION, 2,
-		EGL_NONE,
-	};
-
-	EGLint window_attribs[] = {
-		EGL_RENDER_BUFFER, EGL_BACK_BUFFER,
-		EGL_NONE,
-	};
-
-	int major, minor;
 	int ret;
-
-	memset(&pgl_config, 0, sizeof(pgl_config));
+	unsigned int buttons=0;
+	ret=orbisPadUpdate();
+	if(ret==0)
 	{
-		pgl_config.size = sizeof(pgl_config);
-		pgl_config.flags = SCE_PGL_FLAGS_USE_COMPOSITE_EXT | SCE_PGL_FLAGS_USE_FLEXIBLE_MEMORY | 0x60;
-		pgl_config.processOrder = 1;
-		pgl_config.systemSharedMemorySize = 0x200000;
-		pgl_config.videoSharedMemorySize = 0x2400000;
-		pgl_config.maxMappedFlexibleMemory = 0xAA00000;
-		pgl_config.drawCommandBufferSize = 0xC0000;
-		pgl_config.lcueResourceBufferSize = 0x10000;
-		pgl_config.dbgPosCmd_0x40 = 1920;
-		pgl_config.dbgPosCmd_0x44 = 1080;
-		pgl_config.dbgPosCmd_0x48 = 0;
-		pgl_config.dbgPosCmd_0x4C = 0;
-		pgl_config.unk_0x5C = 2;
-	}
-
-	if (!scePigletSetConfigurationVSH(&pgl_config)) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] scePigletSetConfigurationVSH failed.\n");
-		goto err;
-	}
-
-	s_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-	if (s_display == EGL_NO_DISPLAY) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglGetDisplay failed.\n");
-		goto err;
-	}
-	
-	
-    if (eglInitialize(s_display, &major, &minor) != EGL_TRUE)
-    {
-        ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglInitialize failed: 0x%08X\n", ret);
-		goto err;
-    }
-
-
-	/*if (!eglInitialize(s_display, &major, &minor)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglInitialize failed: 0x%08X\n", ret);
-		goto err;
-	}*/
-	debugNetPrintf(INFO,"[ORBIS_GL] EGL version major:%d, minor:%d\n", major, minor);
-
-	
-	if (!eglBindAPI(EGL_OPENGL_ES_API)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglBindAPI failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	if (!eglSwapInterval(s_display, 0)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapInterval failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	if (!eglChooseConfig(s_display, attribs, &config, 1, &num_configs)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglChooseConfig failed: 0x%08X\n", ret);
-		goto err;
-	}
-	//debugNetPrintf(ERROR,"[ORBIS_GL] num_configs: %d\n", num_configs);
-	if (num_configs != 1) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] No available configuration found.\n");
-		goto err;
-	}
-
-	s_surface = eglCreateWindowSurface(s_display, config, &render_window, window_attribs);
-	if (s_surface == EGL_NO_SURFACE) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglCreateWindowSurface failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	s_context = eglCreateContext(s_display, config, EGL_NO_CONTEXT, ctx_attribs);
-	if (s_context == EGL_NO_CONTEXT) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglCreateContext failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	if (!eglMakeCurrent(s_display, s_surface, s_surface, s_context)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglMakeCurrent failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-    const char *s;
-    s = eglQueryString(s_display, EGL_VERSION);
-    debugNetPrintf(INFO,"EGL_VERSION: %s\n", s);
-    
-    s = eglQueryString(s_display, EGL_VENDOR);
-    debugNetPrintf(INFO,"EGL_VENDOR: %s\n", s);
-
-    s = eglQueryString(s_display, EGL_EXTENSIONS);
-    debugNetPrintf(INFO,"EGL_EXTENSIONS:\n", s);
-   //print_extension_list((char *) s);
-
-    s = eglQueryString(s_display, EGL_CLIENT_APIS);
-    debugNetPrintf(INFO,"EGL_CLIENT_APIS: %s\n", s);
-
-    debugNetPrintf(INFO,"GL_RENDERER   = %s\n", (char *) glGetString(GL_RENDERER));
-    debugNetPrintf(INFO,"GL_VERSION    = %s\n", (char *) glGetString(GL_VERSION));
-    debugNetPrintf(INFO,"GL_VENDOR     = %s\n", (char *) glGetString(GL_VENDOR));
-    debugNetPrintf(INFO,"GL_EXTENSIONS = %s\n", (char *) glGetString(GL_EXTENSIONS));
-    
-	return true;
-
-err:
-	return false;
-}
-
-static void destroy_context(void) {
-	int ret;
-
-	if (!eglDestroyContext(s_display, s_context)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglDestroyContext failed: 0x%08X\n", ret);
-	}
-	s_context = EGL_NO_CONTEXT;
-
-	if (!eglDestroySurface(s_display, s_surface)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglDestroySurface failed: 0x%08X\n", ret);
-	}
-	s_surface = EGL_NO_SURFACE;
-
-	if (!eglTerminate(s_display)) {
-		ret = eglGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] eglTerminate failed: 0x%08X\n", ret);
-	}
-	s_display = EGL_NO_DISPLAY;
-}
-
-static bool create_texture(void) {
-	int ret;
-
-	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glPixelStorei failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glGenTextures(1, &s_texture_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glGenTextures failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glBindTexture(GL_TEXTURE_2D, s_texture_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glBindTexture failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 2, 2, 0, GL_RGB, GL_UNSIGNED_BYTE, s_texture_data);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glTexImage2D failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glTexParameteri failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glTexParameteri failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	return true;
-
-err:
-	return false;
-}
-
-static bool destroy_texture(void) {
-	int ret;
-
-	glDeleteTextures(1, &s_texture_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteTextures failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	return true;
-
-err:
-	return false;
-}
-
-// vertex
-// shader
-static bool compile_shader(GLenum type, const char* source, size_t length, GLuint* pShader) {
-	GLuint shader;
-	GLint tmp_length = (int)length;
-	GLint success;
-	char log_buf[256];
-	int ret;
-
-	shader = glCreateShader(type);
-	if (!shader) {
-		ret = glGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] glCreateShader failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-    // shader from source
-	glShaderSource(shader, 1, &source, &tmp_length);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glShaderSource failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glCompileShader(shader);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glCompileShader failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glGetShaderiv failed: 0x%08X\n", ret);
-		goto err;
-	}
-	if (!success) {
-		glGetShaderInfoLog(shader, sizeof(log_buf), NULL, log_buf);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glGetShaderInfoLog failed: 0x%08X\n", ret);
-			goto err;
+		if(orbisPadGetButtonPressed(ORBISPAD_L2|ORBISPAD_R2) || orbisPadGetButtonHold(ORBISPAD_L2|ORBISPAD_R2))
+		{
+			debugNetPrintf(DEBUG,"Combo L2R2 pressed\n");
+			buttons=orbisPadGetCurrentButtonsPressed();
+			buttons&= ~(ORBISPAD_L2|ORBISPAD_R2);
+			orbisPadSetCurrentButtonsPressed(buttons);
 		}
-		if (strlen(log_buf) > 1) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] shader compilation failed with log:\n%s\n", log_buf);
-		} else {
-			debugNetPrintf(ERROR,"[ORBIS_GL] shader compilation failed\n");
+		if(orbisPadGetButtonPressed(ORBISPAD_L1|ORBISPAD_R1) )
+		{
+			debugNetPrintf(DEBUG,"Combo L1R1 pressed\n");
+			buttons=orbisPadGetCurrentButtonsPressed();
+			buttons&= ~(ORBISPAD_L1|ORBISPAD_R1);
+			orbisPadSetCurrentButtonsPressed(buttons);
 		}
-		goto err;
-	}
-
-	if (pShader) {
-		*pShader = shader;
-	}
-
-	return true;
-
-err:
-	return false;
-}
-
-static bool create_program(void) {
-	GLuint vertex_shader_id = 0;
-	GLuint fragment_shader_id = 0;
-	GLuint program_id = 0;
-	GLint success;
-	char log[256];
-	int ret;
-
-	if (!compile_shader(GL_VERTEX_SHADER, s_vertex_shader_code, strlen(s_vertex_shader_code), &vertex_shader_id)) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to compile vertex shader.\n");
-		goto err;
-	}
-
-	if (!compile_shader(GL_FRAGMENT_SHADER, s_fragment_shader_code, strlen(s_fragment_shader_code), &fragment_shader_id)) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to compile fragment shader.\n");
-		goto err;
-	}
-
-
-/*// Program setup
-
-One you have successfully compiled the shader objects of interest, you can link them into a program. This begins by creating a program object via this command:
-GLuint glCreateProgram();
-*/
-// Vertex and fragment shaders are successfully compiled.
-// Now time to link them together into a program.
-// Get a program object.
-//GLuint program = glCreateProgram();
-	program_id = glCreateProgram();
-	if (!program_id) {
-		ret = glGetError();
-		debugNetPrintf(ERROR,"[ORBIS_GL] glCreateProgram failed: 0x%08X\n", ret);
-		goto err;
-	}
-/*
-After creating a program, the shader objects you wish to link to it must be attached to the program. This is done via this function:
-void glAttachShader(GLuint program​, GLuint shader​);
-*/
-
-// Attach our shaders to our program
-	glAttachShader(program_id, vertex_shader_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glAttachShader(vertex_shader) failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glAttachShader(program_id, fragment_shader_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glAttachShader(fragment_shader) failed: 0x%08X\n", ret);
-		goto err;
-	}
-// Link our program
-	glLinkProgram(program_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glLinkProgram() failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glGetProgramiv(program_id, GL_LINK_STATUS, &success);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glGetProgramiv() failed: 0x%08X\n", ret);
-		goto err;
-	}
-	if (!success) {
-		glGetProgramInfoLog(program_id, sizeof(log), NULL, log);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glGetProgramInfoLog failed: 0x%08X\n", ret);
-			goto err;
+		if(orbisPadGetButtonPressed(ORBISPAD_L1|ORBISPAD_R2) || orbisPadGetButtonHold(ORBISPAD_L1|ORBISPAD_R2))
+		{
+			debugNetPrintf(DEBUG,"Combo L1R2 pressed\n");
+			buttons=orbisPadGetCurrentButtonsPressed();
+			buttons&= ~(ORBISPAD_L1|ORBISPAD_R2);
+			orbisPadSetCurrentButtonsPressed(buttons);
 		}
-		if (strlen(log) > 1) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] Unable to link shader program:\n%s\n", log);
-		} else {
-			debugNetPrintf(ERROR,"[ORBIS_GL] Unable to link shader program.\n");
+		if(orbisPadGetButtonPressed(ORBISPAD_L2|ORBISPAD_R1) || orbisPadGetButtonHold(ORBISPAD_L2|ORBISPAD_R1) )
+		{
+			debugNetPrintf(DEBUG,"Combo L2R1 pressed\n");
+			buttons=orbisPadGetCurrentButtonsPressed();
+			buttons&= ~(ORBISPAD_L2|ORBISPAD_R1);
+			orbisPadSetCurrentButtonsPressed(buttons);
 		}
-		goto err;
-	}
-
-// We don't need the program anymore.
-//	glDeleteProgram(program);
-	
-// Don't leak shaders either.
-	glDeleteShader(fragment_shader_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(fragment_shader) failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	glDeleteShader(vertex_shader_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(vertex_shader) failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	s_xyz_loc = glGetAttribLocation(program_id, "a_xyz");
-	s_uv_loc = glGetAttribLocation(program_id, "a_uv");
-	s_sampler_loc = glGetUniformLocation(program_id, "s_texture");
-
-	s_program_id = program_id;
-
-	return true;
-
-err:
-	if (program_id > 0) {
-		glDeleteProgram(program_id);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteProgram failed: 0x%08X\n", ret);
-			goto err;
+		if(orbisPadGetButtonPressed(ORBISPAD_UP) || orbisPadGetButtonHold(ORBISPAD_UP))
+		{
+			debugNetPrintf(DEBUG,"Up pressed\n");
+			gears_special(2);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_DOWN) || orbisPadGetButtonHold(ORBISPAD_DOWN))
+		{
+			debugNetPrintf(DEBUG,"Down pressed\n");
+			gears_special(3);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_RIGHT) || orbisPadGetButtonHold(ORBISPAD_RIGHT))
+		{
+			debugNetPrintf(DEBUG,"Right pressed\n");
+			gears_special(1);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_LEFT) || orbisPadGetButtonHold(ORBISPAD_LEFT))
+		{
+			debugNetPrintf(DEBUG,"Left pressed\n");
+			gears_special(0);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_TRIANGLE))
+		{
+			debugNetPrintf(DEBUG,"Triangle pressed exit\n");
+			flag=0;
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_CIRCLE))
+		{
+			debugNetPrintf(DEBUG,"Circle pressed\n");
+			orbisAudioResume(0);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_CROSS))
+		{
+			debugNetPrintf(DEBUG,"Cross pressed rand color\n");
+			//orbisAudioStop();
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_SQUARE))
+		{
+			debugNetPrintf(DEBUG,"Square pressed\n");
+			orbisAudioPause(0);
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_L1))
+		{
+			debugNetPrintf(DEBUG,"L1 pressed\n");
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_L2))
+		{
+			debugNetPrintf(DEBUG,"L2 pressed\n");
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_R1))
+		{
+			debugNetPrintf(DEBUG,"R1 pressed\n");
+		}
+		if(orbisPadGetButtonPressed(ORBISPAD_R2))
+		{
+			debugNetPrintf(DEBUG,"R2 pressed\n");
 		}
 	}
-
-	if (fragment_shader_id > 0) {
-		glDeleteShader(fragment_shader_id);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(fragment_shader) failed: 0x%08X\n", ret);
-			goto err;
-		}
-		fragment_shader_id = 0;
-	}
-
-	if (vertex_shader_id > 0) {
-		glDeleteShader(vertex_shader_id);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteShader(vertex_shader) failed: 0x%08X\n", ret);
-			goto err;
-		}
-		vertex_shader_id = 0;
-	}
-
-	return false;
 }
 
-static bool destroy_program(void) {
-	int ret;
 
-	glDeleteProgram(s_program_id);
-	ret = glGetError();
-	if (ret) {
-		debugNetPrintf(ERROR,"[ORBIS_GL] glDeleteProgram failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	return true;
-
-err:
-	return false;
+void finishApp()
+{
+	orbisAudioFinish();
+	orbisKeyboardFinish();
+	orbisGlFinish();
+	orbisPadFinish();
+	orbisFileFinish();
+	ps4LinkFinish();
 }
 
-////
-bool initAppGl()
+
+static bool initAppGl()
 {
 	int ret;
 	ret=orbisGlInit(ATTR_ORBISGL_WIDTH,ATTR_ORBISGL_HEIGHT);
@@ -549,14 +164,14 @@ bool initAppGl()
 			ret=glGetError();
 			if(ret)
 			{
-				debugNetPrintf(ERROR,"[ORBISGLPERF] glViewport failed: 0x%08X\n",ret);
+				debugNetPrintf(ERROR,"glViewport failed: 0x%08X\n",ret);
 				return false;
 			}
-			glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+			glClearColor(0.0f, 0.0f, 1.0f, 1.0f); //blue RGBA
 			ret=glGetError();
 			if(ret)
 			{
-				debugNetPrintf(ERROR,"[ORBISGLPERF] glClearColor failed: 0x%08X\n",ret);
+				debugNetPrintf(ERROR,"glClearColor failed: 0x%08X\n",ret);
 				return false;
 			}
 			return true;
@@ -565,142 +180,72 @@ bool initAppGl()
 }
 
 
+bool initApp()
+{
+	int ret;
+	sceSystemServiceHideSplashScreen();
+	//more library initialiazation here pad,filebroser,audio,keyboard, etc
+	//....
+	orbisFileInit();
+	ret=orbisPadInitWithConf(myConf->confPad);
+	if(ret)
+	{
+		confPad=orbisPadGetConf();
+		ret=orbisAudioInitWithConf(myConf->confAudio);
+		if(ret==1)
+		{
+			ret=orbisKeyboardInitWithConf(myConf->confKeyboard);
+			if(ret!=1)
+				return false;
+		}
+	}
+	else
+	{
+		return false;
+	}
+	if(!initAppGl())
+		return false;
 
-/// main loop for gears
+	return true;
+}
+
+
+/// main rendering loop
 int frame = 0;
-static bool main_loop2(void) {
+static bool main_loop(void)
+{
 	int ret;
 
-	while (1)
+	while (flag)
 	{
+		updateController();
+
 	    glClear(GL_COLOR_BUFFER_BIT);
 		ret = glGetError();
 		if (ret) {
 			debugNetPrintf(ERROR,"[ORBIS_GL] glClear failed: 0x%08X\n", ret);
 			goto err;
 		}
-		
+
 		/// draw
 		gears_draw();
-		
-		gears_idle(frame);
-	    
+
+		// animate
+		gears_idle(&flag);
+
 	    // flip frame
-	    if (!eglSwapBuffers(s_display, s_surface)) {
-			ret = eglGetError();
-			debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapBuffers failed: 0x%08X\n", ret);
-			goto err;
-		}
+        orbisGlSwapBuffers();
 	}
-
 	return true;
 
 err:
 	return false;
 }
-
-
-static bool main_loop(void) {
-	int ret;
-
-float i = 0.0;
-	while (1)
-	{
-	    /*if(i>256) i = 0.0;
-	    glClearColor(0.0f, i, i, 1.0f);
-	    debugNetPrintf(ERROR,"i: %.3f\n", i);
-	    i++;*/
-	    
-		glClear(GL_COLOR_BUFFER_BIT);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glClear failed: 0x%08X\n", ret);
-			goto err;
-		}
-		
-		//gears_draw();
-#if 1
-		glUseProgram(s_program_id);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glUseProgram failed: 0x%08X\n", ret);
-			goto err;
-		}
-//glVertexAttribPointer
-		glVertexAttribPointer(s_xyz_loc, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), s_obj_vertices);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glVertexAttribPointer failed: 0x%08X\n", ret);
-			goto err;
-		}
-		glVertexAttribPointer(s_uv_loc, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), &s_obj_vertices[3]);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glVertexAttribPointer failed: 0x%08X\n", ret);
-			goto err;
-		}
-
-// glEnableVertexAttribArray
-		glEnableVertexAttribArray(s_xyz_loc);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glEnableVertexAttribArray failed: 0x%08X\n", ret);
-			goto err;
-		}
-		glEnableVertexAttribArray(s_uv_loc);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glEnableVertexAttribArray failed: 0x%08X\n", ret);
-			goto err;
-		}
-
-//glActiveTexture
-		glActiveTexture(GL_TEXTURE0);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glActiveTexture failed: 0x%08X\n", ret);
-			goto err;
-		}
-		glBindTexture(GL_TEXTURE_2D, s_texture_id);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glBindTexture failed: 0x%08X\n", ret);
-			goto err;
-		}
-
-		glUniform1i(s_sampler_loc, 0);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glUniform1i failed: 0x%08X\n", ret);
-			goto err;
-		}
-
-		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, s_obj_indices);
-		ret = glGetError();
-		if (ret) {
-			debugNetPrintf(ERROR,"[ORBIS_GL] glDrawElements failed: 0x%08X\n", ret);
-			goto err;
-		}
-#endif
-		if (!eglSwapBuffers(s_display, s_surface)) {
-			ret = eglGetError();
-			debugNetPrintf(ERROR,"[ORBIS_GL] eglSwapBuffers failed: 0x%08X\n", ret);
-			goto err;
-		}
-	}
-
-	return true;
-
-err:
-	return false;
-}
-
 
 
 int main(int argc, char *argv[])
 {
 	int ret;
-
 
 	uintptr_t intptr=0;
 	sscanf(argv[1],"%p",&intptr);
@@ -711,82 +256,36 @@ int main(int argc, char *argv[])
 		ps4LinkFinish();
 		return 0;
 	}
-	debugNetPrintf(INFO,"[ORBIS_GL] Hello from first gl es sample with hitodama's sdk and liborbis\n");	
+	debugNetPrintf(INFO,"[ORBIS_GL] Hello from GL ES sample with hitodama's sdk and liborbis\n");
 	sleep(1);
 
-	ret=sceSystemServiceHideSplashScreen();
-	if(ret) 
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] sceSystemServiceHideSplashScreen failed: 0x%08X\n", ret);
-		goto err;
-	}
-
-	if(!create_context(ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT)) 
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create context.\n");
-		goto err;
-	}
-
-#if 0	
-/////	
-	if(!create_texture()) 
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create texture.\n");
-		goto err_destroy_context;
-	}
-
-////
-	if(!create_program())
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] Unable to create shader program.\n");
-		//
-        goto err_destroy_texture;
-	}
-#endif
-
-	glViewport(0, 0, ATTR_ORBISGL_WIDTH, ATTR_ORBISGL_HEIGHT);
-	ret = glGetError();
+	// init libraries
+	flag=initApp();
+	
+	Mod_Init(0);
+    ret = Mod_Load("host0:main.mod");
 	if(ret)
+	    Mod_Play();
+
+	orbisAudioResume(0);
+
+    // e2gears: build shaders, setup initial state, etc.
+    es2gears_init();
+
+    // enter main render loop
+	if (!main_loop())
 	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] glViewport failed: 0x%08X\n", ret);
-		goto err_destroy_program;
+		debugNetPrintf(ERROR,"[ORBIS_GL] Main loop stopped.\n");
+		goto err;
 	}
-
-	glClearColor(0.0f, 0.0f, 1.0f, 1.0f);  // blue
-	ret = glGetError();
-	if (ret) 
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] glClearColor failed: 0x%08X\n", ret);
-		goto err_destroy_program;
-	}
-
-#if 1
-debugNetPrintf(ERROR,"[ORBIS_GL] call test()\n");
-test();
-debugNetPrintf(ERROR,"[ORBIS_GL] after test()\n");
-#endif
-
-//goto err;  // force exit
-
-	if (!main_loop2()) 
-	{
-		debugNetPrintf(ERROR,"[ORBIS_GL] Main loop failed.\n");
-		goto err_destroy_program;
-	}
-
-	err_destroy_program:
-		destroy_program();
-
-	err_destroy_texture:
-		destroy_texture();
-
-	err_destroy_context:
-		destroy_context();
 
 	err:
-	
-	
-	ps4LinkFinish();
-	
+
+	orbisAudioPause(0);
+	Mod_End();
+
+	// finish libraries
+	finishApp();
+
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
I have ported [this](https://github.com/freedesktop/mesa-demos/blob/master/src/egl/opengles2/es2gears.c) example, first porting to liborbis, then moved to liborbisGl: this gives a nice code cleanup reusing most from the new library

- commit 007bc73 show how I have ported

- basically, the ES2 part is left untouched